### PR TITLE
read the comment and bounce if the comment does not set

### DIFF
--- a/func/wallet-v4-code.fc
+++ b/func/wallet-v4-code.fc
@@ -1,27 +1,62 @@
-#pragma version =0.2.0;
+#pragma version =0.4.4;
+#include "imports/stdlib.fc";
 ;; Wallet smart contract with plugins
 
 (slice, int) dict_get?(cell dict, int key_len, slice index) asm(index dict key_len) "DICTGET" "NULLSWAPIFNOT";
 (cell, int) dict_add_builder?(cell dict, int key_len, slice index, builder value) asm(value index dict key_len) "DICTADDB";
 (cell, int) dict_delete?(cell dict, int key_len, slice index) asm(index dict key_len) "DICTDEL";
 
+slice read_comment(slice in_msg) impure {
+    int need_break = 0;
+    builder result = begin_cell();
+    do {
+        result = result.store_slice(in_msg~load_bits(in_msg.slice_bits()));
+        int refs_len = in_msg.slice_refs();
+        need_break = refs_len == 0;
+        if (~ need_break) {
+            throw_unless(202, refs_len == 1);
+            in_msg = in_msg~load_ref().begin_parse();
+        }
+    } until (need_break);
+    return result.end_cell().begin_parse();
+}
+
+() send_payment(int amount, slice address) impure inline {
+    var msg = begin_cell()
+        .store_uint(0x10, 6) ;; nobounce
+        .store_slice(address)
+        .store_grams(amount)
+        .store_uint(0, 107)
+        .end_cell();
+
+    send_raw_message(msg, 2);
+}
+
 () recv_internal(int msg_value, cell in_msg_cell, slice in_msg) impure {
   var cs = in_msg_cell.begin_parse();
   var flags = cs~load_uint(4);  ;; int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
+  slice comment = read_comment(in_msg);
+  slice s_addr = cs~load_msg_addr();
   if (flags & 1) {
     ;; ignore all bounced messages
     return ();
   }
+
+  if (slice_empty?(comment)) {
+    send_payment(msg_value, s_addr);
+  }
+;;   throw_if(100, slice_empty?(comment));
+
   if (in_msg.slice_bits() < 32) {
     ;; ignore simple transfers
     return ();
   }
+
   int op = in_msg~load_uint(32);
   if (op != 0x706c7567) & (op != 0x64737472) { ;; "plug" & "dstr"
     ;; ignore all messages not related to plugins
     return ();
   }
-  slice s_addr = cs~load_msg_addr();
   (int wc, int addr_hash) = parse_std_addr(s_addr);
   slice wc_n_address = begin_cell().store_int(wc, 8).store_uint(addr_hash, 256).end_cell().begin_parse();
   var ds = get_data().begin_parse().skip_bits(32 + 32 + 256);


### PR DESCRIPTION
در این pr کامنت های تراکنش تون در ولت v4 خوانده می شود. سپس اگر کامنت ست نشده بود، بدون توجه به
bounceable یا non-bounceable
آنها amount واریزی را به ولت مبدا برمیگرداند.
ابتدا به یک ارور اکتفا میکردیم : throw_if(100, slice_empty?(comment));
در لاین ۴۷ کد ولت این قابل مشاهده است. با throw کردن فقط برگشت تراکنش های bounceable ساپورت می شد. نمونه تراکنش ها در این ولت قابل مشاهده است:
https://testnet.tonscan.org/address/EQAZKXNO5yNIbvXYItPK_A8tpYuqOtx6N5178_RVCn046HnN

در توضیح تراکنش ها:
تراکنش non-bounceable بدون کامنت که ارور ثبت می شود ولی مقدار در مقصد می نشیند:
https://testnet.tonscan.org/tx/ZpgQXOV5QRM4B1n0iTQh3liMWlYPyGV05bYjjMn1QJ8=
تراکنش bounceable بدون کامنت که ارور ثبت می شود و مقدار برگشت داده می شود:
https://testnet.tonscan.org/tx/xOHfKOVrMsYMZt0y8MIn5Y9IHx31w7FkxnjEZR4lPE8=
تراکنش با کامنت:
https://testnet.tonscan.org/tx/vyhfK81nmP9wbwyMogGaSK7_jEPuQBBilQHWBUwzxNk=

در آپدیت بعدی به جای throw سعی کردیم بدون توجه به
bounceable یا non-bounceable
بودن تراکنش های بدون کامنت را به ولت مبدا بازگردانیم. پس تراکنش بازگشتی را در اسمارت کانترکت می سازیم. این کار با خواندن کامنت و چک کردن خالی نبودن آن انجام شده است. لاین 44 تا 46 نشان دهنده این موضوع است. تراکنش های نمونه در این ولت قابل مشاهده است:
https://testnet.tonscan.org/address/EQCHLVfaJNAcR9ZQzTbEhsdhBB1rn-fKF2tlagqC0eok6q_c
تراکنش نان بانسبل برگشت خورده به دلیل عدم وجود ممو:
https://testnet.tonscan.org/tx/8Iu3hZLhvDZ1USgE_QH8ZNk_1OYg2nMyZ7syLuOqrLE=
تراکنش بانسبل برگشت خورده به دلیل عدم وجود ممو:
https://testnet.tonscan.org/tx/3ccmyV9vYcXnnM3RTrpxvvpokw43nVveze6SmuYYjmA=
تراکنش با ممو که بدون مشکل ثبت می شود:
https://testnet.tonscan.org/tx/CfnVykr054Yq1netIYBdnx7jrS9VNbUN2_PKXIZ0OZg=